### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/hemcefor/2ae53676-2c57-44ab-9bb2-29ea0514a424/68915caa-2cef-4610-84bc-ffd45fbae3a7/_apis/work/boardbadge/0e9317c5-aac4-4a51-81c1-b66f310e9706)](https://dev.azure.com/hemcefor/2ae53676-2c57-44ab-9bb2-29ea0514a424/_boards/board/t/68915caa-2cef-4610-84bc-ffd45fbae3a7/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/hemcefor/2ae53676-2c57-44ab-9bb2-29ea0514a424/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.